### PR TITLE
Set SparkRuntime to null in the constructor of JMetalSPApplication.

### DIFF
--- a/jmetalsp-core/src/main/java/org/uma/jmetalsp/application/JMetalSPApplication.java
+++ b/jmetalsp-core/src/main/java/org/uma/jmetalsp/application/JMetalSPApplication.java
@@ -35,7 +35,7 @@ public class JMetalSPApplication<
   public JMetalSPApplication() {
     this.streamingDataSourceList = null;
     this.algorithmDataConsumerList = null ;
-    sparkRuntime = new SparkRuntime(1) ;
+    this.sparkRuntime = null ;
   }
 
   public JMetalSPApplication setProblemBuilder(ProblemBuilder<P> problemBuilder) {


### PR DESCRIPTION
This solves the error of multiple contexts in Spark.
